### PR TITLE
Update parse-command.ts

### DIFF
--- a/src/utils/parse-command.ts
+++ b/src/utils/parse-command.ts
@@ -1,15 +1,15 @@
-export interface Commands {
-  prefix: string;
-  command: string;
-  args: string[];
-}
+export function parseCommand(message: string): Commands {{
+  const commandRegex = /(@gibworkbot tip) (\d+) (@\w+)/;
+  const match = message.match(commandRegex);
 
-export function parseCommand(message: string): Commands {
-  const [prefix, command, ...args] = message.split(' ');
+  if (match) {{
+    const [ , command, ...args ] = match;
+    return {{
+      prefix: '@gibworkbot',
+      command,
+      args,
+    }};
+  }}
 
-  return {
-    prefix,
-    command,
-    args,
-  };
-}
+  throw new Error('Command not found in message');
+}}


### PR DESCRIPTION
The issue seems to be related to how the bot is parsing the command from the message. The current implementation might be expecting the command to be at the start of the message.

i modified the parseCommand function in parse-command.ts to search the entire message for the command, not just at the start. i used a regular expression to find the command and its arguments within the message.